### PR TITLE
Fix password reset email delivery via Resend

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3002,6 +3002,7 @@
       "integrity": "sha512-D2wOSq/d6Agt28q7rSI3jhU7G6aiuzljDGZ2hTZHIkrTLUI+AF3WMeKkEZ9nN2fkBAlcktT6vcZjDFiIhMYEQw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -3013,6 +3014,7 @@
       "integrity": "sha512-qW1Mfv8taImTthu4KoXgDfLuk4bydU6Q/TkADnDWWHwi4NX4BR+LWfTp2sVmTqRrsHvyDDTelgelxJ+SsejKKQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -3066,6 +3068,7 @@
       "integrity": "sha512-lmt73NeHdy1Q/2ul295Qy3uninSqi6wQI18XwSpm8w0ZbQXUpjCAWP1Vlv/obudoBiIjJVjlztjQ+d/Md98Yxg==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.11.0",
         "@typescript-eslint/types": "8.11.0",
@@ -3274,6 +3277,7 @@
       "integrity": "sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3478,6 +3482,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001669",
         "electron-to-chromium": "^1.5.41",
@@ -4173,6 +4178,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-3.6.0.tgz",
       "integrity": "sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -4254,7 +4260,8 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.3.0.tgz",
       "integrity": "sha512-Ve8dhI4w28qBqR8J+aMtv7rLK89r1ZA5HocwFz6uMB/i5EiC7bGI7y+AM80yAVUJw3qqaZYK7clmZMUR8kM3UA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/embla-carousel-react": {
       "version": "8.3.0",
@@ -4352,6 +4359,7 @@
       "integrity": "sha512-EYZK6SX6zjFHST/HRytOdA/zE72Cq/bfw45LSyuwrdvcclb/gqV8RRQxywOBEWO2+WDpva6UZa4CcDeJKzUCFA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.11.0",
@@ -5906,6 +5914,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.0",
@@ -6092,6 +6101,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -6118,6 +6128,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -6131,6 +6142,7 @@
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.53.1.tgz",
       "integrity": "sha512-6aiQeBda4zjcuaugWvim9WsGqisoUk+etmFEsSUMm451/Ic8L/UAb7sRtMj3V+Hdzm6mMjU1VhiSzYUZeBm0Vg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },
@@ -6691,6 +6703,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -6828,6 +6841,7 @@
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6997,6 +7011,7 @@
       "integrity": "sha512-1hvaPshuPUtxeQ0hsVH3Mud0ZanOLwVTneA1EgbAM5LhaZEqyPWGRQ7BtaMvUrTDeEaC8pxtj6a6jku3x4z6SQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",

--- a/src/hooks/useUserManagement.tsx
+++ b/src/hooks/useUserManagement.tsx
@@ -189,13 +189,42 @@ export const useUserManagement = () => {
   };
 
   const resetUserPassword = async (email: string) => {
+    const redirectTo = window.location.origin + '/auth?mode=reset';
+
     try {
-      const { error } = await supabase.auth.resetPasswordForEmail(email, {
-        redirectTo: window.location.origin + '/auth?mode=reset'
+      const { data: { session } } = await supabase.auth.getSession();
+
+      if (!session) {
+        toast.error('You must be logged in to reset passwords');
+        return false;
+      }
+
+      // Primary path: send the reset link through Resend via our edge function.
+      // Supabase's built-in mailer is rate-limited and silently drops emails in
+      // production, which is why admins were not receiving reset links.
+      const { data, error } = await supabase.functions.invoke('reset-user-password', {
+        body: { email, redirectTo },
+        headers: {
+          Authorization: `Bearer ${session.access_token}`,
+        },
       });
 
-      if (error) {
-        console.error('Error sending reset email:', error);
+      if (!error && data?.success) {
+        toast.success('Password reset email sent successfully');
+        return true;
+      }
+
+      // If the edge function isn't deployed or the email service isn't
+      // configured, fall back to the built-in mailer so behavior degrades
+      // gracefully rather than failing outright.
+      console.warn('reset-user-password edge function unavailable, falling back to built-in mailer:', error || data);
+
+      const { error: fallbackError } = await supabase.auth.resetPasswordForEmail(email, {
+        redirectTo,
+      });
+
+      if (fallbackError) {
+        console.error('Error sending reset email:', fallbackError);
         toast.error('Failed to send password reset email');
         return false;
       }

--- a/supabase/functions/reset-user-password/index.ts
+++ b/supabase/functions/reset-user-password/index.ts
@@ -1,0 +1,203 @@
+// Supabase Edge Function for sending password reset emails via Resend.
+// This runs in the Deno runtime, not Node.js - local linter errors are expected.
+//
+// Why this exists:
+//   Supabase's built-in email service is heavily rate-limited and not meant for
+//   production. Reset emails sent through it silently fail to deliver once the
+//   limit is hit. This function generates a recovery link with the admin API and
+//   delivers it through Resend (the same provider already used for student
+//   reports), which is reliable and not rate-limited.
+import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2'
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+}
+
+const createResetEmailTemplate = (resetLink: string, schoolName: string) => {
+  return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Reset Your Password</title>
+</head>
+<body style="margin:0; padding:0; background-color:#f1f5f9; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;">
+  <div style="max-width:560px; margin:0 auto; padding:32px 20px;">
+    <div style="background:#ffffff; border-radius:16px; overflow:hidden; box-shadow:0 4px 16px rgba(0,0,0,0.06);">
+      <div style="background:linear-gradient(135deg,#2563eb,#4f46e5); padding:32px; text-align:center;">
+        <h1 style="margin:0; color:#ffffff; font-size:22px; font-weight:700;">${schoolName}</h1>
+        <p style="margin:8px 0 0; color:#dbeafe; font-size:14px;">Student Progress Tracker</p>
+      </div>
+      <div style="padding:32px;">
+        <h2 style="margin:0 0 16px; color:#0f172a; font-size:20px;">Reset your password</h2>
+        <p style="margin:0 0 24px; color:#475569; font-size:15px; line-height:1.6;">
+          We received a request to reset the password for your ARCC account. Click the
+          button below to choose a new password. This link will expire in 1 hour.
+        </p>
+        <div style="text-align:center; margin:0 0 24px;">
+          <a href="${resetLink}" style="display:inline-block; background:linear-gradient(135deg,#2563eb,#4f46e5); color:#ffffff; text-decoration:none; padding:14px 32px; border-radius:10px; font-weight:600; font-size:15px;">
+            Reset Password
+          </a>
+        </div>
+        <p style="margin:0 0 8px; color:#94a3b8; font-size:13px; line-height:1.6;">
+          If the button doesn't work, copy and paste this link into your browser:
+        </p>
+        <p style="margin:0 0 24px; word-break:break-all;">
+          <a href="${resetLink}" style="color:#2563eb; font-size:13px;">${resetLink}</a>
+        </p>
+        <p style="margin:0; color:#94a3b8; font-size:13px; line-height:1.6;">
+          If you didn't request this, you can safely ignore this email — your password
+          will remain unchanged.
+        </p>
+      </div>
+      <div style="background:#f8fafc; padding:20px 32px; border-top:1px solid #e2e8f0;">
+        <p style="margin:0; color:#94a3b8; font-size:12px; text-align:center;">
+          🔒 This is an automated security email from ${schoolName}.
+        </p>
+      </div>
+    </div>
+  </div>
+</body>
+</html>
+  `;
+};
+
+serve(async (req) => {
+  // Handle CORS preflight requests
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', { headers: corsHeaders })
+  }
+
+  try {
+    // Admin client with the service role key for privileged operations
+    const supabaseAdmin = createClient(
+      Deno.env.get('SUPABASE_URL') ?? '',
+      Deno.env.get('SUPABASE_SERVICE_ROLE_KEY') ?? '',
+      {
+        auth: {
+          autoRefreshToken: false,
+          persistSession: false
+        }
+      }
+    )
+
+    // Verify the request comes from an authenticated admin/teacher
+    const authHeader = req.headers.get('Authorization')
+    if (!authHeader) {
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+    const token = authHeader.replace('Bearer ', '')
+
+    const { data: { user }, error: authError } = await supabaseAdmin.auth.getUser(token)
+    if (authError || !user) {
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized' }),
+        { status: 401, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Only admins and teachers can trigger password resets for other users
+    const { data: userRoles, error: rolesError } = await supabaseAdmin
+      .from('user_roles')
+      .select('role')
+      .eq('user_id', user.id)
+
+    if (rolesError || !userRoles?.some(r => r.role === 'admin' || r.role === 'teacher')) {
+      return new Response(
+        JSON.stringify({ error: 'Admin or teacher access required' }),
+        { status: 403, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Parse request body
+    const { email, redirectTo } = await req.json()
+
+    if (!email) {
+      return new Response(
+        JSON.stringify({ error: 'Email is required' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const resendApiKey = Deno.env.get('RESEND_API_KEY')
+    if (!resendApiKey) {
+      console.error('RESEND_API_KEY not found in environment variables')
+      return new Response(
+        JSON.stringify({ error: 'Email service not configured' }),
+        { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    // Generate a password recovery link using the admin API.
+    // This works regardless of the built-in email rate limits because we
+    // deliver the link ourselves through Resend.
+    const { data: linkData, error: linkError } = await supabaseAdmin.auth.admin.generateLink({
+      type: 'recovery',
+      email,
+      options: redirectTo ? { redirectTo } : undefined,
+    })
+
+    if (linkError || !linkData?.properties?.action_link) {
+      console.error('Error generating recovery link:', linkError)
+      // Most common cause: the email does not correspond to an existing user.
+      return new Response(
+        JSON.stringify({ error: linkError?.message || 'Could not generate reset link for this email' }),
+        { status: 400, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const resetLink = linkData.properties.action_link
+    const schoolName = 'Rising Sun Montessori'
+    const fromAddress = Deno.env.get('RESET_EMAIL_FROM') ?? 'ARCC <onboarding@resend.dev>'
+
+    // Send the reset email through Resend
+    const emailResponse = await fetch('https://api.resend.com/emails', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${resendApiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        from: fromAddress,
+        to: [email],
+        subject: 'Reset your ARCC password',
+        html: createResetEmailTemplate(resetLink, schoolName),
+        text: `Reset your ARCC password by visiting this link (expires in 1 hour):\n\n${resetLink}\n\nIf you didn't request this, you can ignore this email.`,
+      }),
+    })
+
+    if (!emailResponse.ok) {
+      const errorData = await emailResponse.text()
+      console.error('Resend API error:', errorData)
+      return new Response(
+        JSON.stringify({ error: 'Failed to send reset email', details: errorData }),
+        { status: 502, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+      )
+    }
+
+    const emailResult = await emailResponse.json()
+    console.log('Password reset email sent successfully:', emailResult?.id)
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        emailId: emailResult?.id,
+        message: `Password reset email sent to ${email}`,
+      }),
+      { headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+
+  } catch (error) {
+    console.error('Edge function error:', error)
+    return new Response(
+      JSON.stringify({ error: 'Internal server error', details: error?.message }),
+      { status: 500, headers: { ...corsHeaders, 'Content-Type': 'application/json' } }
+    )
+  }
+})


### PR DESCRIPTION
Route admin password resets through a new reset-user-password edge function that generates a recovery link and delivers it through Resend, with a safe fallback to the built-in mailer. Fixes reset emails silently failing due to Supabase's rate-limited default mailer.