### PR TITLE
Add Review Queue, Attendance Insights, real analytics, and Help redesign

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import Settings from "./pages/Settings";
 import AttendanceManagement from "./pages/AttendanceManagement";
 import Analytics from "./pages/Analytics";
 import Help from "./pages/Help";
+import ReviewQueue from "./pages/ReviewQueue";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -55,6 +56,11 @@ const AppWithRealtime = () => {
         <Route path="/attendance" element={
           <ProtectedPageWrapper>
             <AttendanceManagement />
+          </ProtectedPageWrapper>
+        } />
+        <Route path="/review" element={
+          <ProtectedPageWrapper>
+            <ReviewQueue />
           </ProtectedPageWrapper>
         } />
         <Route path="/analytics" element={

--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
-import { Home, Users, LogOut, Settings, UserCheck, ChevronLeft, ChevronRight, BarChart3, HelpCircle } from 'lucide-react';
+import { Home, Users, LogOut, Settings, UserCheck, ChevronLeft, ChevronRight, BarChart3, HelpCircle, ClipboardCheck } from 'lucide-react';
 import { NavLink } from 'react-router-dom';
 import { useAuth } from '@/contexts/AuthContext';
 import { useUserRole } from '@/hooks/useUserRole';
+import { useTasks } from '@/hooks/useTasks';
+import { Badge } from '@/components/ui/badge';
 import {
   Sidebar,
   SidebarContent,
@@ -19,6 +21,7 @@ import { Button } from '@/components/ui/button';
 const items = [
   { title: 'Dashboard', url: '/', icon: Home },
   { title: 'Attendance', url: '/attendance', icon: UserCheck, teacherOnly: true },
+  { title: 'Review Queue', url: '/review', icon: ClipboardCheck, teacherOnly: true, badgeKey: 'readyReview' },
   { title: 'Manage Tasks', url: '/settings', icon: Settings, teacherOnly: true },
   { title: 'Analytics', url: '/analytics', icon: BarChart3, adminOnly: true },
   { title: 'User Management', url: '/users', icon: Users, adminOnly: true },
@@ -29,9 +32,11 @@ export function AppSidebar() {
   const { state } = useSidebar();
   const { signOut, user } = useAuth();
   const { isAdmin, isTeacher } = useUserRole();
+  const { tasks } = useTasks();
 
   const isCollapsed = state === 'collapsed';
   const { toggleSidebar } = useSidebar();
+  const readyReviewCount = tasks.filter(task => task.status === 'ready-review').length;
 
   const handleSignOut = async () => {
     await signOut();
@@ -113,6 +118,11 @@ export function AppSidebar() {
                   >
                     <item.icon className={`${isCollapsed ? 'h-4 w-4' : 'h-4 w-4'} flex-shrink-0`} />
                     {!isCollapsed && <span className="truncate">{item.title}</span>}
+                    {!isCollapsed && item.badgeKey === 'readyReview' && readyReviewCount > 0 && (
+                      <Badge className="ml-auto bg-amber-100 text-amber-800 hover:bg-amber-100">
+                        {readyReviewCount}
+                      </Badge>
+                    )}
                   </NavLink>
                 </SidebarMenuItem>
               ))}

--- a/src/components/FleetBoard.tsx
+++ b/src/components/FleetBoard.tsx
@@ -27,6 +27,21 @@ const FleetBoard: React.FC<FleetBoardProps> = ({
   console.log('FleetBoard props:', { students, subjects, tasks, statusFilter });
   const { isPresentationMode } = usePresentationMode();
 
+  const getAgeInMinutes = (dateValue?: string) => {
+    if (!dateValue) return 0;
+    const timestamp = new Date(dateValue).getTime();
+    if (Number.isNaN(timestamp)) return 0;
+    return Math.max(0, Math.floor((Date.now() - timestamp) / (1000 * 60)));
+  };
+
+  const formatAge = (minutes: number) => {
+    if (minutes < 60) return `${minutes} minutes`;
+    const hours = Math.floor(minutes / 60);
+    if (hours < 48) return `${hours} hours`;
+    const days = Math.floor(hours / 24);
+    return `${days} days`;
+  };
+
   const getTasksForStudentAndSubject = (studentId: string, subject: string): Task[] => {
     const studentTasks = tasks.filter(task => task.studentId === studentId);
     const subjectTasks = studentTasks.filter(task => task.subject === subject);
@@ -41,17 +56,23 @@ const FleetBoard: React.FC<FleetBoardProps> = ({
   };
 
   const getStudentsNeedingAttention = () => {
-    const needingHelp = tasks.filter(task => 
-      task.status === 'need-help' && task.timeInStatus >= 5
-    );
+    const needingHelp = tasks.filter(task => {
+      const ageMinutes = getAgeInMinutes(task.updatedAt || task.createdAt);
+      return (
+        (task.status === 'need-help' && ageMinutes >= 30) ||
+        (task.status === 'ready-review' && ageMinutes >= 60 * 24 * 7)
+      );
+    });
     
     return needingHelp.map(task => {
       const student = students.find(s => s.id === task.studentId);
+      const ageMinutes = getAgeInMinutes(task.updatedAt || task.createdAt);
       return {
         studentName: student?.name || 'Unknown',
         taskTitle: task.title,
         subject: task.subject,
-        timeNeedingHelp: task.timeInStatus
+        timeNeedingHelp: formatAge(ageMinutes),
+        status: task.status
       };
     });
   };
@@ -178,7 +199,9 @@ const FleetBoard: React.FC<FleetBoardProps> = ({
             {attentionNeeded.map((item, index) => (
               <li key={index} className="text-sm text-amber-700 bg-white/60 rounded-lg p-3 border border-amber-200">
                 <strong className="text-amber-900">{item.studentName}</strong> - {item.subject}: {item.taskTitle} 
-                <span className="text-amber-600 font-medium"> (needs help for {item.timeNeedingHelp} minutes)</span>
+                <span className="text-amber-600 font-medium">
+                  {' '}({item.status === 'ready-review' ? 'waiting for review' : 'needs help'} for {item.timeNeedingHelp})
+                </span>
               </li>
             ))}
           </ul>

--- a/src/components/StudentDetailsModal.tsx
+++ b/src/components/StudentDetailsModal.tsx
@@ -39,6 +39,15 @@ interface StudentDetailsModalProps {
   onClose: () => void;
 }
 
+interface SubjectBreakdown {
+  total: number;
+  todo: number;
+  working: number;
+  needHelp: number;
+  readyReview: number;
+  completed: number;
+}
+
 const StudentDetailsModal: React.FC<StudentDetailsModalProps> = ({
   student,
   isOpen,
@@ -103,7 +112,7 @@ const StudentDetailsModal: React.FC<StudentDetailsModalProps> = ({
       }
       
       return acc;
-    }, {} as Record<string, any>);
+    }, {} as Record<string, SubjectBreakdown>);
 
     // Attendance calculations
     const totalAttendanceDays = studentAttendance.length;
@@ -130,7 +139,6 @@ const StudentDetailsModal: React.FC<StudentDetailsModalProps> = ({
       presentDays,
       recentTasks: recentTasks.length,
       completionRate,
-      averageGrade: 'A-', // Placeholder - you can calculate from actual grades
       subjectCount: Object.keys(tasksBySubject).length
     };
   }, [student, tasks, attendance]);
@@ -204,7 +212,7 @@ const StudentDetailsModal: React.FC<StudentDetailsModalProps> = ({
             <div class="section-title">Performance by Subject</div>
             <table>
               <tr><th>Subject</th><th>Total Tasks</th><th>Completed</th><th>Completion Rate</th></tr>
-              ${Object.entries(studentAnalytics.tasksBySubject).map(([subject, data]: [string, any]) => 
+              ${Object.entries(studentAnalytics.tasksBySubject).map(([subject, data]) => 
                 `<tr><td>${subject}</td><td>${data.total}</td><td>${data.completed}</td><td>${Math.round((data.completed / data.total) * 100) || 0}%</td></tr>`
               ).join('')}
             </table>
@@ -320,7 +328,7 @@ Please find below the progress report for ${student.name}:
 • Ready for Review: ${studentAnalytics.tasksByStatus.readyReview.length}
 
 📚 SUBJECT PERFORMANCE:
-${Object.entries(studentAnalytics.tasksBySubject).map(([subject, data]: [string, any]) => 
+${Object.entries(studentAnalytics.tasksBySubject).map(([subject, data]) => 
   `• ${subject}: ${data.completed}/${data.total} completed (${Math.round((data.completed / data.total) * 100) || 0}%)`
 ).join('\n')}
 
@@ -467,7 +475,7 @@ The Teaching Team
             </CardHeader>
             <CardContent>
               <div className="space-y-3">
-                {Object.entries(studentAnalytics.tasksBySubject).map(([subject, data]: [string, any]) => {
+                {Object.entries(studentAnalytics.tasksBySubject).map(([subject, data]) => {
                   const completionRate = Math.round((data.completed / data.total) * 100) || 0;
                   return (
                     <div key={subject} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -294,8 +294,8 @@ const TaskCard: React.FC<TaskCardProps> = ({ task, onUpdateStatus }) => {
                 <div className="text-xs font-semibold text-gray-700 uppercase tracking-wide">Task Management</div>
               </div>
               <div className="space-y-2">
-                {/* Feedback Button - Prominent for completed tasks */}
-                {task.status === 'completed' && (
+                {/* Feedback Button - available once work is ready for teacher review */}
+                {(task.status === 'ready-review' || task.status === 'completed') && (
                   <button
                     onClick={handleGiveFeedback}
                     className="w-full flex items-center gap-3 px-4 py-3 text-xs font-medium text-purple-700 bg-purple-50/70 hover:bg-purple-100/80 rounded-lg transition-all duration-200 hover:shadow-sm hover:scale-[1.01] active:scale-[0.99] border border-purple-100/60 hover:border-purple-200/80 group"

--- a/src/components/TeacherFeedbackDialog.tsx
+++ b/src/components/TeacherFeedbackDialog.tsx
@@ -28,9 +28,10 @@ interface TeacherFeedbackDialogProps {
   task: Task | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
+  completeOnSave?: boolean;
 }
 
-export const TeacherFeedbackDialog = ({ task, open, onOpenChange }: TeacherFeedbackDialogProps) => {
+export const TeacherFeedbackDialog = ({ task, open, onOpenChange, completeOnSave = false }: TeacherFeedbackDialogProps) => {
   const { updateTask, isUpdating } = useTasks();
   const { user } = useAuth();
   const [selectedFeedbackType, setSelectedFeedbackType] = useState<TeacherFeedbackType>('thumbs_up');
@@ -60,7 +61,8 @@ export const TeacherFeedbackDialog = ({ task, open, onOpenChange }: TeacherFeedb
       ...data,
       teacher_feedback_type: selectedFeedbackType,
       feedback_given_at: new Date().toISOString(),
-      feedback_given_by: user.id
+      feedback_given_by: user.id,
+      ...(completeOnSave ? { status: 'completed' as const } : {})
     };
 
     updateTask({ 
@@ -130,7 +132,7 @@ export const TeacherFeedbackDialog = ({ task, open, onOpenChange }: TeacherFeedb
               <p className="text-sm text-blue-700 mb-2">{task.description}</p>
             )}
             <div className="text-xs text-blue-600">
-              Completed: {new Date(task.updated_at).toLocaleDateString('en-US', { 
+              Submitted: {new Date(task.updated_at).toLocaleDateString('en-US', { 
                 weekday: 'short', 
                 month: 'short', 
                 day: 'numeric',
@@ -227,7 +229,7 @@ export const TeacherFeedbackDialog = ({ task, open, onOpenChange }: TeacherFeedb
               disabled={isUpdating}
               className="bg-blue-600 hover:bg-blue-700"
             >
-              {isUpdating ? 'Saving...' : 'Save Feedback'}
+              {isUpdating ? 'Saving...' : completeOnSave ? 'Complete & Save Feedback' : 'Save Feedback'}
             </Button>
           </DialogFooter>
         </form>

--- a/src/hooks/useAttendanceHistory.tsx
+++ b/src/hooks/useAttendanceHistory.tsx
@@ -1,0 +1,37 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { useAuth } from '@/contexts/AuthContext';
+import { useUserRole } from '@/hooks/useUserRole';
+import type { Attendance } from '@/hooks/useAttendance';
+
+export const useAttendanceHistory = (enabled = true) => {
+  const { user } = useAuth();
+  const { isAdmin, isTeacher, loading: roleLoading } = useUserRole();
+
+  const query = useQuery({
+    queryKey: ['attendance-history'],
+    queryFn: async (): Promise<Attendance[]> => {
+      const { data, error } = await supabase
+        .from('attendance')
+        .select('*')
+        .order('date', { ascending: true });
+
+      if (error) {
+        console.error('Error fetching attendance history:', error);
+        throw error;
+      }
+
+      return data || [];
+    },
+    enabled: enabled && !!user?.id && !roleLoading && (isAdmin || isTeacher),
+    staleTime: 1000 * 60 * 5,
+    refetchOnWindowFocus: false,
+  });
+
+  return {
+    attendanceHistory: query.data || [],
+    loading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
+  };
+};

--- a/src/hooks/useStudents.tsx
+++ b/src/hooks/useStudents.tsx
@@ -7,6 +7,8 @@ export interface Student {
   id: string;
   name: string;
   grade: string;
+  // Present on the students table and returned by select('*')
+  email?: string | null;
   created_at: string;
   updated_at: string;
 }

--- a/src/pages/Analytics.tsx
+++ b/src/pages/Analytics.tsx
@@ -2,13 +2,16 @@ import React, { useMemo, useState } from 'react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { useTasks } from '@/hooks/useTasks';
 import { useStudents } from '@/hooks/useStudents';
+import type { Student } from '@/hooks/useStudents';
 import { useSubjects } from '@/hooks/useSubjects';
 import { useAttendance } from '@/hooks/useAttendance';
+import { useAttendanceHistory } from '@/hooks/useAttendanceHistory';
 import { useUserRole } from '@/hooks/useUserRole';
 import StudentDetailsModal from '@/components/StudentDetailsModal';
 import HelpTooltip from '@/components/HelpTooltip';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
 import { 
   BarChart3, 
   TrendingUp, 
@@ -30,7 +33,8 @@ import {
   Activity,
   UserCheck,
   FileText,
-  Zap
+  Zap,
+  Download
 } from 'lucide-react';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Progress } from '@/components/ui/progress';
@@ -41,6 +45,7 @@ const Analytics = () => {
   const { students } = useStudents();
   const { subjects } = useSubjects();
   const { attendance } = useAttendance();
+  const { attendanceHistory } = useAttendanceHistory(isAdmin);
 
   // Modal state for student details
   const [selectedStudent, setSelectedStudent] = useState<{
@@ -50,9 +55,11 @@ const Analytics = () => {
     grade?: string;
   } | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [attendanceStartDate, setAttendanceStartDate] = useState('');
+  const [attendanceEndDate, setAttendanceEndDate] = useState('');
 
   // Handle student row click
-  const handleStudentClick = (student: any) => {
+  const handleStudentClick = (student: Student) => {
     setSelectedStudent({
       id: student.id,
       name: student.name,
@@ -61,20 +68,6 @@ const Analytics = () => {
     });
     setIsModalOpen(true);
   };
-
-  // Redirect if not admin
-  if (!isAdmin) {
-    return (
-      <div className="p-6">
-        <Alert className="border-red-200 bg-red-50">
-          <AlertCircle className="h-4 w-4 text-red-600" />
-          <AlertDescription className="text-red-700">
-            Access denied. Analytics dashboard is only available to administrators.
-          </AlertDescription>
-        </Alert>
-      </div>
-    );
-  }
 
   // Calculate analytics data
   const analytics = useMemo(() => {
@@ -97,6 +90,28 @@ const Analytics = () => {
         }
         return lastSchoolDay.toISOString().split('T')[0];
       }
+    };
+
+    const averageHoursBetween = (records: Array<{ created_at?: string; updated_at?: string; feedback_given_at?: string | null }>, endField: 'updated_at' | 'feedback_given_at') => {
+      const durations = records
+        .map((record) => {
+          const start = record.created_at ? new Date(record.created_at).getTime() : NaN;
+          const endValue = record[endField];
+          const end = endValue ? new Date(endValue).getTime() : NaN;
+          if (Number.isNaN(start) || Number.isNaN(end) || end < start) return null;
+          return (end - start) / (1000 * 60 * 60);
+        })
+        .filter((duration): duration is number => duration !== null);
+
+      if (durations.length === 0) return null;
+      return Math.round(durations.reduce((sum, duration) => sum + duration, 0) / durations.length);
+    };
+
+    const formatHours = (hours: number | null) => {
+      if (hours === null) return 'No data yet';
+      if (hours < 24) return `${hours}h`;
+      const days = Math.round((hours / 24) * 10) / 10;
+      return `${days}d`;
     };
 
     // Enhanced student performance metrics with feedback analysis
@@ -127,9 +142,7 @@ const Analytics = () => {
         ? Math.round((positiveFeedback.length / tasksWithFeedback.length) * 100)
         : 0;
 
-      // Calculate average time to completion (mock data for now)
-      const avgCompletionTime = completedTasks.length > 0 ? 
-        Math.round(Math.random() * 48 + 12) : 0; // 12-60 hours
+      const avgCompletionTime = averageHoursBetween(completedTasks, 'updated_at');
 
       return {
         id: student.id,
@@ -144,7 +157,7 @@ const Analytics = () => {
         completionRate,
         feedbackRate,
         positivityScore,
-        avgCompletionTime,
+        avgCompletionTime: formatHours(avgCompletionTime),
         positiveFeedback: positiveFeedback.length,
         negativeFeedback: negativeFeedback.length,
         neutralFeedback: neutralFeedback.length,
@@ -152,20 +165,23 @@ const Analytics = () => {
       };
     }).sort((a, b) => b.completionRate - a.completionRate);
 
+    const feedbackTasks = tasks.filter(task => task.teacher_feedback_type);
+    const completedTasksForFeedback = tasks.filter(task => task.status === 'completed');
+
     // Teacher feedback analytics
     const feedbackAnalytics = {
-      totalFeedbackGiven: tasks.filter(task => task.teacher_feedback_type).length,
+      totalFeedbackGiven: feedbackTasks.length,
       completedTasksWithFeedback: tasks.filter(task => 
         task.status === 'completed' && task.teacher_feedback_type
       ).length,
-      completedTasksTotal: tasks.filter(task => task.status === 'completed').length,
+      completedTasksTotal: completedTasksForFeedback.length,
       positiveFeedback: tasks.filter(task => task.teacher_feedback_type === 'thumbs_up').length,
       negativeFeedback: tasks.filter(task => task.teacher_feedback_type === 'thumbs_down').length,
       neutralFeedback: tasks.filter(task => task.teacher_feedback_type === 'neutral').length,
-      averageResponseTime: '4.2 hours', // Mock data - would calculate from feedback_given_at vs task completion
-      feedbackCompletionRate: tasks.filter(task => task.status === 'completed').length > 0 ?
+      averageResponseTime: formatHours(averageHoursBetween(feedbackTasks, 'feedback_given_at')),
+      feedbackCompletionRate: completedTasksForFeedback.length > 0 ?
         Math.round((tasks.filter(task => task.status === 'completed' && task.teacher_feedback_type).length / 
-                   tasks.filter(task => task.status === 'completed').length) * 100) : 0
+                   completedTasksForFeedback.length) * 100) : 0
     };
 
     // Subject performance analysis
@@ -216,6 +232,58 @@ const Analytics = () => {
     const activeStudents = new Set(tasks.map(task => task.student_id)).size;
     const engagementRate = students.length > 0 ? Math.round((activeStudents / students.length) * 100) : 0;
 
+    const filteredAttendanceHistory = attendanceHistory.filter((record) => {
+      if (attendanceStartDate && record.date < attendanceStartDate) return false;
+      if (attendanceEndDate && record.date > attendanceEndDate) return false;
+      return true;
+    });
+
+    const monthlyAttendance = Object.values(
+      filteredAttendanceHistory.reduce<Record<string, { month: string; present: number; total: number }>>((acc, record) => {
+        const month = record.date.slice(0, 7);
+        if (!acc[month]) acc[month] = { month, present: 0, total: 0 };
+        acc[month].total += 1;
+        if (record.is_present) acc[month].present += 1;
+        return acc;
+      }, {})
+    ).map((month) => ({
+      ...month,
+      rate: month.total > 0 ? Math.round((month.present / month.total) * 100) : 0,
+    })).sort((a, b) => a.month.localeCompare(b.month));
+
+    const studentAttendanceRates = students.map((student) => {
+      const records = filteredAttendanceHistory.filter(record => record.student_id === student.id);
+      const present = records.filter(record => record.is_present).length;
+      const rate = records.length > 0 ? Math.round((present / records.length) * 100) : null;
+
+      return {
+        id: student.id,
+        name: student.name,
+        grade: student.grade,
+        present,
+        absent: records.length - present,
+        total: records.length,
+        rate,
+        chronicFlag: rate !== null && rate < 90
+      };
+    }).sort((a, b) => {
+      if (a.rate === null && b.rate === null) return a.name.localeCompare(b.name);
+      if (a.rate === null) return 1;
+      if (b.rate === null) return -1;
+      return a.rate - b.rate;
+    });
+
+    const attendanceInsights = {
+      totalRecords: filteredAttendanceHistory.length,
+      monthlyAttendance,
+      studentAttendanceRates,
+      chronicAbsenceCount: studentAttendanceRates.filter(student => student.chronicFlag).length,
+      perfectAttendanceCount: studentAttendanceRates.filter(student => student.rate === 100).length,
+      averageHistoricalRate: filteredAttendanceHistory.length > 0
+        ? Math.round((filteredAttendanceHistory.filter(record => record.is_present).length / filteredAttendanceHistory.length) * 100)
+        : null
+    };
+
     return {
       totalStudents: students.length,
       activeStudents,
@@ -230,13 +298,14 @@ const Analytics = () => {
       studentMetrics,
       feedbackAnalytics,
       subjectAnalytics,
+      attendanceInsights,
       topPerformers,
       strugglingStudents,
       mostPositiveFeedback,
       currentSchoolDay: getCurrentSchoolDay(),
       isCurrentlySchoolDay
     };
-  }, [students, tasks, subjects, attendance]);
+  }, [students, tasks, subjects, attendance, attendanceHistory, attendanceStartDate, attendanceEndDate]);
 
   // Simple bar chart component
   const SimpleBarChart = ({ data, title, colorClass = "bg-blue-500" }: { data: Record<string, number>, title: string, colorClass?: string }) => {
@@ -266,6 +335,56 @@ const Analytics = () => {
       </div>
     );
   };
+
+  const handleExportAttendanceCsv = () => {
+    const rows = analytics.attendanceInsights.studentAttendanceRates.map((student) => ({
+      Student: student.name,
+      Grade: student.grade,
+      Present: student.present,
+      Absent: student.absent,
+      Total: student.total,
+      'Attendance Rate': student.rate === null ? 'No data' : `${student.rate}%`,
+      Flag: student.chronicFlag ? 'Below 90%' : ''
+    }));
+
+    const headers = Object.keys(rows[0] || {
+      Student: '',
+      Grade: '',
+      Present: '',
+      Absent: '',
+      Total: '',
+      'Attendance Rate': '',
+      Flag: ''
+    });
+
+    const escapeCsv = (value: unknown) => `"${String(value ?? '').replace(/"/g, '""')}"`;
+    const csv = [
+      headers.map(escapeCsv).join(','),
+      ...rows.map((row) => headers.map((header) => escapeCsv(row[header as keyof typeof row])).join(','))
+    ].join('\n');
+
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = `attendance-insights-${new Date().toISOString().split('T')[0]}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  // Redirect if not admin. Keep this after all hooks to preserve hook order.
+  if (!isAdmin) {
+    return (
+      <div className="p-6">
+        <Alert className="border-red-200 bg-red-50">
+          <AlertCircle className="h-4 w-4 text-red-600" />
+          <AlertDescription className="text-red-700">
+            Access denied. Analytics dashboard is only available to administrators.
+          </AlertDescription>
+        </Alert>
+      </div>
+    );
+  }
 
   return (
     <div className="space-y-6 p-6">
@@ -853,7 +972,7 @@ const Analytics = () => {
               <div className="flex items-center justify-between">
                 <span className="text-sm text-gray-600">Students with Perfect Attendance</span>
                 <span className="font-medium text-emerald-600">
-                  {Math.floor(analytics.totalStudents * 0.75)} {/* Placeholder - you can calculate actual */}
+                  {analytics.attendanceInsights.perfectAttendanceCount}
                 </span>
               </div>
               <div className="flex items-center justify-between">
@@ -881,6 +1000,132 @@ const Analytics = () => {
           </CardContent>
         </Card>
       </div>
+
+      {/* Attendance Insights - Historical */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between gap-3">
+            <div className="flex items-center gap-2">
+              <UserCheck className="h-5 w-5 text-emerald-600" />
+              Attendance Insights
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <Button variant="outline" size="sm" onClick={handleExportAttendanceCsv}>
+                <Download className="mr-2 h-4 w-4" />
+                CSV
+              </Button>
+              <Button variant="outline" size="sm" onClick={() => window.print()}>
+                <FileText className="mr-2 h-4 w-4" />
+                Print
+              </Button>
+            </div>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+            <div className="space-y-2 md:col-span-1">
+              <label className="text-sm font-medium text-gray-700">From</label>
+              <Input
+                type="date"
+                value={attendanceStartDate}
+                onChange={(event) => setAttendanceStartDate(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2 md:col-span-1">
+              <label className="text-sm font-medium text-gray-700">To</label>
+              <Input
+                type="date"
+                value={attendanceEndDate}
+                onChange={(event) => setAttendanceEndDate(event.target.value)}
+              />
+            </div>
+            <div className="rounded-lg border border-emerald-200 bg-emerald-50 p-4">
+              <div className="text-sm text-emerald-700">Historical Rate</div>
+              <div className="text-2xl font-bold text-emerald-900">
+                {analytics.attendanceInsights.averageHistoricalRate === null
+                  ? 'No data'
+                  : `${analytics.attendanceInsights.averageHistoricalRate}%`}
+              </div>
+              <div className="text-xs text-emerald-700">{analytics.attendanceInsights.totalRecords} records</div>
+            </div>
+            <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
+              <div className="text-sm text-amber-700">Below 90%</div>
+              <div className="text-2xl font-bold text-amber-900">{analytics.attendanceInsights.chronicAbsenceCount}</div>
+              <div className="text-xs text-amber-700">students to monitor</div>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            <div>
+              <SimpleBarChart
+                data={analytics.attendanceInsights.monthlyAttendance.reduce((acc, month) => {
+                  acc[month.month] = month.rate;
+                  return acc;
+                }, {} as Record<string, number>)}
+                title="Monthly Attendance Rate"
+                colorClass="bg-gradient-to-r from-emerald-500 to-green-500"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-4">
+              <div className="rounded-lg bg-blue-50 p-4 text-center border border-blue-200">
+                <div className="text-2xl font-bold text-blue-800">{analytics.attendanceInsights.perfectAttendanceCount}</div>
+                <div className="text-sm text-blue-700">Perfect Attendance</div>
+              </div>
+              <div className="rounded-lg bg-gray-50 p-4 text-center border border-gray-200">
+                <div className="text-2xl font-bold text-gray-800">{analytics.attendanceInsights.monthlyAttendance.length}</div>
+                <div className="text-sm text-gray-700">Months Tracked</div>
+              </div>
+            </div>
+          </div>
+
+          <div className="overflow-x-auto rounded-lg border border-gray-200">
+            <table className="w-full">
+              <thead className="bg-gray-50">
+                <tr>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-gray-700">Student</th>
+                  <th className="px-4 py-3 text-center text-sm font-medium text-gray-700">Present</th>
+                  <th className="px-4 py-3 text-center text-sm font-medium text-gray-700">Absent</th>
+                  <th className="px-4 py-3 text-center text-sm font-medium text-gray-700">Rate</th>
+                  <th className="px-4 py-3 text-center text-sm font-medium text-gray-700">Flag</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-100">
+                {analytics.attendanceInsights.studentAttendanceRates.map((student) => (
+                  <tr key={student.id} className="hover:bg-gray-50">
+                    <td className="px-4 py-3">
+                      <div className="font-medium text-gray-900">{student.name}</div>
+                      <div className="text-xs text-gray-500">Grade {student.grade}</div>
+                    </td>
+                    <td className="px-4 py-3 text-center text-sm text-gray-700">{student.present}</td>
+                    <td className="px-4 py-3 text-center text-sm text-gray-700">{student.absent}</td>
+                    <td className="px-4 py-3 text-center">
+                      <Badge
+                        variant="outline"
+                        className={
+                          student.rate === null
+                            ? 'border-gray-200 text-gray-600'
+                            : student.rate < 90
+                              ? 'border-amber-200 text-amber-700'
+                              : 'border-emerald-200 text-emerald-700'
+                        }
+                      >
+                        {student.rate === null ? 'No data' : `${student.rate}%`}
+                      </Badge>
+                    </td>
+                    <td className="px-4 py-3 text-center">
+                      {student.chronicFlag ? (
+                        <Badge className="bg-amber-100 text-amber-800 hover:bg-amber-100">Below 90%</Badge>
+                      ) : (
+                        <span className="text-xs text-gray-400">—</span>
+                      )}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </CardContent>
+      </Card>
 
       {/* Student Details Modal */}
       <StudentDetailsModal

--- a/src/pages/Help.tsx
+++ b/src/pages/Help.tsx
@@ -14,6 +14,7 @@ import {
   Settings, 
   UserPlus, 
   CheckCircle, 
+  ClipboardCheck,
   Eye, 
   Filter, 
   Download, 
@@ -32,7 +33,7 @@ import {
 const Help = () => {
   const { isAdmin, isTeacher, isStudent } = useUserRole();
   const [searchTerm, setSearchTerm] = useState('');
-  const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set(['getting-started']));
+  const [expandedSections, setExpandedSections] = useState<Set<string>>(new Set(['getting-started', 'review-queue']));
   const [selectedCategory, setSelectedCategory] = useState<string>('all');
 
   const toggleSection = (sectionId: string) => {
@@ -63,17 +64,17 @@ const Help = () => {
         {
           title: 'First Login & Navigation',
           content: [
-            '1. Log in with your teacher or admin credentials',
-            '2. You\'ll land on the Dashboard (FleetBoard) showing all student progress',
-            '3. Use the sidebar to navigate between different sections',
-            '4. Check the header for your check-in status and user menu'
+            '1. Log in with your teacher or admin credentials.',
+            '2. You\'ll land on the Dashboard (FleetBoard) showing all student progress.',
+            '3. Use the sidebar to navigate between Dashboard, Attendance, Review Queue, Manage Tasks, Analytics, and Help.',
+            '4. Watch the Review Queue badge to see how many submitted activities are waiting for review.'
           ]
         },
         {
           title: 'User Interface Overview',
           content: [
             '• **Sidebar**: Main navigation menu with all available features',
-            '• **Header**: Shows current page, check-in button, and user profile',
+            '• **Review Queue Badge**: Shows how many activities are currently waiting for teacher review',
             '• **Main Content**: Displays the selected page content',
             '• **Notifications**: Toast messages appear for important updates'
           ]
@@ -121,6 +122,51 @@ const Help = () => {
             'No need to refresh - changes appear instantly across all connected devices.',
             'Perfect for classroom TV displays and teacher monitoring.'
           ]
+        },
+        {
+          title: 'Students Need Attention',
+          content: [
+            'The dashboard highlights students who may need follow-up based on task age.',
+            'Need Help tasks are flagged when they have been waiting for help for more than 30 minutes.',
+            'Ready Review tasks are flagged when they have been waiting for review for more than a week.',
+            'Use these alerts to decide whether to help a student, review their work, or send the task back for revisions.'
+          ]
+        }
+      ]
+    },
+    {
+      id: 'review-queue',
+      title: 'Review Queue',
+      icon: ClipboardCheck,
+      category: 'core',
+      roles: ['teacher', 'admin'],
+      isNew: true,
+      sections: [
+        {
+          title: 'What the Review Queue Is For',
+          content: [
+            'The Review Queue shows all learning activities that students have marked as Ready Review.',
+            'It is the main place for teachers to clear submitted work, provide feedback, and move tasks to Completed.',
+            'The number badge in the sidebar shows how many activities are waiting for review.'
+          ]
+        },
+        {
+          title: 'Review Actions',
+          content: [
+            '• **Send Back**: Moves the activity back to Working when the student needs to revise or continue.',
+            '• **Mark Complete**: Approves the activity without adding written feedback.',
+            '• **Complete + Feedback**: Opens the feedback dialog and saves feedback while marking the task Completed in one step.'
+          ]
+        },
+        {
+          title: 'Recommended Review Workflow',
+          content: [
+            '1. Open Review Queue at the start or end of each work cycle.',
+            '2. Start with the oldest submissions first so work does not sit unreviewed.',
+            '3. Use Complete + Feedback when students need encouragement or next steps.',
+            '4. Use Send Back when a task is not ready to complete yet.',
+            '5. After review, check Analytics to see updated completion and feedback metrics.'
+          ]
         }
       ]
     },
@@ -134,21 +180,22 @@ const Help = () => {
         {
           title: 'Creating New Tasks',
           content: [
-            '1. Navigate to "Manage Tasks" in the sidebar',
-            '2. Fill in the task details: title, description, subject',
-            '3. Select which students should receive the task',
-            '4. Set any due dates or special instructions',
-            '5. Click "Create Task" to assign it to selected students'
+            '1. Navigate to "Manage Tasks" in the sidebar.',
+            '2. Fill in the activity name, learning objectives or notes, and subject area.',
+            '3. Select which students should receive the activity.',
+            '4. Click "Create Task" to assign it to selected students.',
+            '5. Created activities begin in TO DO and appear on each student\'s dashboard.'
           ]
         },
         {
           title: 'Task Status Workflow',
           content: [
             'Tasks follow a standard workflow that students can update:',
-            '1. **Working**: Student is actively working on the task',
-            '2. **Need Help**: Student is stuck and requires assistance',
-            '3. **Ready Review**: Student has completed work and wants review',
-            '4. **Completed**: Teacher has reviewed and approved the work'
+            '1. **TO DO**: Activity has been assigned but not started.',
+            '2. **Working**: Student is actively working on the task.',
+            '3. **Need Help**: Student is stuck and requires assistance.',
+            '4. **Ready Review**: Student has submitted work for teacher review.',
+            '5. **Completed**: Teacher has reviewed and approved the work.'
           ]
         },
         {
@@ -156,6 +203,7 @@ const Help = () => {
           content: [
             'Use the dashboard to see real-time status updates from students.',
             'Students can change their status independently to communicate their needs.',
+            'Use the Review Queue for work that is Ready Review.',
             'Teachers can update task status during review or when providing help.'
           ]
         },
@@ -163,8 +211,8 @@ const Help = () => {
           title: 'Editing and Managing Tasks',
           content: [
             'Click on any task card to edit details or update status.',
-            'You can modify task descriptions, due dates, and assignments.',
-            'Delete tasks that are no longer needed from the task management area.'
+            'Use Manage Tasks to edit, reassign, bulk assign, or delete learning activities.',
+            'When deleting one instance of a learning activity, matching activities with the same title and subject are removed from all assigned students.'
           ]
         }
       ]
@@ -198,9 +246,9 @@ const Help = () => {
           title: 'Attendance Analytics',
           content: [
             'View attendance rates and trends in the Analytics section.',
-            'Track which students have perfect attendance.',
-            'Monitor overall class attendance percentages.',
-            'Generate attendance reports for administration.'
+            'Use Attendance Insights to see monthly attendance trends and per-student attendance rates.',
+            'Students below 90% attendance are flagged for follow-up.',
+            'Export attendance insights as CSV or print them for administration.'
           ]
         }
       ]
@@ -216,8 +264,20 @@ const Help = () => {
           title: 'Dashboard Overview',
           content: [
             'The Analytics page provides comprehensive insights into student progress.',
-            'View key metrics: total students, attendance rates, task completion, students needing help.',
-            'Monitor both individual student performance and class-wide trends.'
+            'View key metrics: total students, attendance rates, task completion, students needing help, and feedback activity.',
+            'Monitor both individual student performance and class-wide trends.',
+            'Attendance Insights shows historical attendance patterns beyond today.'
+          ]
+        },
+        {
+          title: 'Attendance Insights',
+          isNew: true,
+          content: [
+            'Use the Attendance Insights section to review historical attendance, not just today\'s check-ins.',
+            'Set a start and end date to focus on a specific time period.',
+            'Review monthly attendance trends and the per-student attendance table.',
+            'Students below 90% attendance are flagged so administrators can follow up.',
+            'Use CSV export for spreadsheets or Print for a quick report.'
           ]
         },
         {
@@ -242,10 +302,11 @@ const Help = () => {
         {
           title: 'Understanding Metrics',
           content: [
-            '• **Completion Rate**: Percentage of assigned tasks completed',
-            '• **Attendance Rate**: Percentage of school days student was present',
+            '• **Completion Rate**: Percentage of assigned tasks completed after teacher review',
+            '• **Attendance Rate**: Percentage of tracked attendance records marked present',
             '• **Task Breakdown**: Distribution across different status categories',
-            '• **Subject Performance**: Progress tracking by academic subject'
+            '• **Subject Performance**: Progress tracking by academic subject',
+            '• **Feedback Response Time**: Shows "No data yet" until feedback exists'
           ]
         }
       ]
@@ -288,8 +349,9 @@ const Help = () => {
           title: 'Password Management',
           content: [
             'Reset user passwords using the password reset form.',
-            'Enter the user\'s email address to generate a new temporary password.',
-            'Users should change their password on first login after reset.'
+            'Enter the user\'s email address to send a secure reset link.',
+            'If reset email delivery is unavailable, an administrator can set a temporary password through Supabase admin tools.',
+            'Users should change temporary passwords after logging in.'
           ]
         }
       ]
@@ -365,9 +427,10 @@ const Help = () => {
           title: 'Classroom Management Tips',
           content: [
             '• Check the dashboard regularly to identify students needing help',
+            '• Use the Review Queue daily so Ready Review work does not pile up',
             '• Use status filters to focus on specific classroom needs',
             '• Encourage students to update their status honestly',
-            '• Review completed work promptly to maintain student engagement'
+            '• Provide feedback promptly to maintain student engagement'
           ]
         },
         {
@@ -469,195 +532,202 @@ const Help = () => {
   ];
 
   return (
-    <div className="space-y-6 p-6">
-      {/* Header */}
-      <div className="flex items-center gap-3">
-        <HelpCircle className="h-8 w-8 text-blue-600" />
-        <div>
-          <h1 className="text-3xl font-bold bg-gradient-to-r from-blue-700 to-indigo-700 bg-clip-text text-transparent">
-            Help & User Guide
-          </h1>
-          <p className="text-gray-600">
-            Complete guide to using the Student Progress Tracking System
-            {isAdmin && ' (Administrator View)'}
-            {isTeacher && !isAdmin && ' (Teacher View)'}
-          </p>
+    <div className="min-h-full space-y-6 bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/50 p-6">
+      {/* Hero */}
+      <div className="overflow-hidden rounded-3xl border border-blue-100 bg-white shadow-sm">
+        <div className="bg-gradient-to-r from-blue-600 to-indigo-600 p-6 sm:p-8">
+          <div className="flex items-start gap-4">
+            <div className="rounded-2xl bg-white/15 p-3 backdrop-blur">
+              <HelpCircle className="h-7 w-7 text-white" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-white sm:text-3xl">Help &amp; User Guide</h1>
+              <p className="mt-1 text-blue-100">
+                Everything you need to run ARCC
+                {isAdmin ? ' as an administrator.' : isTeacher ? ' as a teacher.' : '.'}
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {/* Quick start steps */}
+        <div className="grid gap-4 p-6 md:grid-cols-2">
+          {(isTeacher || isAdmin) && (
+            <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+              <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-slate-700">
+                <Target className="h-4 w-4 text-blue-600" /> Teachers — first steps
+              </h3>
+              <ol className="space-y-2.5 text-sm text-slate-700">
+                <li className="flex items-start gap-3">
+                  <span className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-blue-100 text-xs font-bold text-blue-700">1</span>
+                  <span><span className="font-medium text-slate-900">Dashboard</span> — watch live student progress.</span>
+                </li>
+                <li className="flex items-start gap-3">
+                  <span className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-blue-100 text-xs font-bold text-blue-700">2</span>
+                  <span><span className="font-medium text-slate-900">Manage Tasks</span> — create and assign activities.</span>
+                </li>
+                <li className="flex items-start gap-3">
+                  <span className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-blue-100 text-xs font-bold text-blue-700">3</span>
+                  <span><span className="font-medium text-slate-900">Review Queue</span> — clear submitted work and give feedback.</span>
+                </li>
+              </ol>
+            </div>
+          )}
+
+          {isAdmin && (
+            <div className="rounded-2xl border border-slate-200 bg-slate-50/70 p-4">
+              <h3 className="mb-3 flex items-center gap-2 text-sm font-semibold uppercase tracking-wide text-slate-700">
+                <Shield className="h-4 w-4 text-indigo-600" /> Administrators — setup
+              </h3>
+              <ol className="space-y-2.5 text-sm text-slate-700">
+                <li className="flex items-start gap-3">
+                  <span className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-indigo-100 text-xs font-bold text-indigo-700">1</span>
+                  <span><span className="font-medium text-slate-900">User Management</span> — create teachers and students.</span>
+                </li>
+                <li className="flex items-start gap-3">
+                  <span className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-indigo-100 text-xs font-bold text-indigo-700">2</span>
+                  <span><span className="font-medium text-slate-900">Sync Records</span> — fix data consistency in one click.</span>
+                </li>
+                <li className="flex items-start gap-3">
+                  <span className="mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full bg-indigo-100 text-xs font-bold text-indigo-700">3</span>
+                  <span><span className="font-medium text-slate-900">Analytics</span> — track school-wide performance.</span>
+                </li>
+              </ol>
+            </div>
+          )}
         </div>
       </div>
 
-      {/* Quick Start Section */}
-      <Card className="bg-gradient-to-r from-blue-50 to-indigo-50 border-blue-200">
-        <CardContent className="p-6">
-          <div className="flex items-center gap-3 mb-6">
-            <div className="w-10 h-10 bg-blue-600 rounded-full flex items-center justify-center">
-              <Play className="h-5 w-5 text-white" />
+      {/* What's New */}
+      <div className="rounded-3xl border border-emerald-200 bg-gradient-to-r from-emerald-50 to-green-50 p-5 sm:p-6">
+        <div className="mb-4 flex items-center gap-3">
+          <div className="rounded-xl bg-emerald-600/10 p-2.5">
+            <Star className="h-5 w-5 text-emerald-700" />
+          </div>
+          <div>
+            <h2 className="flex items-center gap-2 text-lg font-bold text-emerald-900">
+              What's New
+              <Badge className="bg-emerald-600 text-white hover:bg-emerald-600">New</Badge>
+            </h2>
+            <p className="text-sm text-emerald-700">Two new ways to keep work moving — tap a card to jump in.</p>
+          </div>
+        </div>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <button
+            type="button"
+            onClick={() => {
+              setSearchTerm('');
+              setSelectedCategory('all');
+              setExpandedSections((prev) => new Set(prev).add('review-queue'));
+            }}
+            className="group flex items-start gap-3 rounded-2xl border border-emerald-200 bg-white p-4 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-emerald-300 hover:shadow-md"
+          >
+            <div className="rounded-xl bg-emerald-100 p-2 text-emerald-700 transition-colors group-hover:bg-emerald-200">
+              <ClipboardCheck className="h-5 w-5" />
             </div>
             <div>
-              <h2 className="text-xl font-bold text-blue-900">🚀 Quick Start Guide</h2>
-              <p className="text-blue-700">Get up and running in just a few steps</p>
+              <div className="flex items-center gap-2 font-semibold text-slate-900">Review Queue</div>
+              <p className="mt-0.5 text-sm text-slate-600">
+                Approve submitted work, send it back, or complete it with feedback in one place.
+              </p>
             </div>
-          </div>
-          
-          <div className="grid md:grid-cols-2 gap-6">
-            {/* Teacher Quick Start */}
-            {(isTeacher || isAdmin) && (
-              <div className="space-y-4">
-                <h3 className="font-semibold text-blue-800 flex items-center gap-2">
-                  <div className="w-6 h-6 bg-blue-100 rounded-full flex items-center justify-center text-xs">
-                    👩‍🏫
-                  </div>
-                  For Teachers - First Steps
-                </h3>
-                <ol className="space-y-3 text-sm">
-                  <li className="flex gap-3">
-                    <span className="w-6 h-6 bg-emerald-100 rounded-full flex items-center justify-center text-xs font-bold text-emerald-600 flex-shrink-0 mt-0.5">1</span>
-                    <div>
-                      <span className="font-medium">Start with the Dashboard</span> - View students and real-time progress
-                    </div>
-                  </li>
-                  <li className="flex gap-3">
-                    <span className="w-6 h-6 bg-emerald-100 rounded-full flex items-center justify-center text-xs font-bold text-emerald-600 flex-shrink-0 mt-0.5">2</span>
-                    <div>
-                      <span className="font-medium">Create Tasks</span> - Go to "Manage Tasks" → Add assignments
-                    </div>
-                  </li>
-                  <li className="flex gap-3">
-                    <span className="w-6 h-6 bg-emerald-100 rounded-full flex items-center justify-center text-xs font-bold text-emerald-600 flex-shrink-0 mt-0.5">3</span>
-                    <div>
-                      <span className="font-medium">Use Filters</span> - Click progress tiles to focus on student needs
-                    </div>
-                  </li>
-                </ol>
-              </div>
-            )}
-            
-            {/* Admin Quick Start */}
-            {isAdmin && (
-              <div className="space-y-4">
-                <h3 className="font-semibold text-blue-800 flex items-center gap-2">
-                  <div className="w-6 h-6 bg-purple-100 rounded-full flex items-center justify-center text-xs">
-                    👨‍💼
-                  </div>
-                  For Administrators - Setup
-                </h3>
-                <ol className="space-y-3 text-sm">
-                  <li className="flex gap-3">
-                    <span className="w-6 h-6 bg-purple-100 rounded-full flex items-center justify-center text-xs font-bold text-purple-600 flex-shrink-0 mt-0.5">1</span>
-                    <div>
-                      <span className="font-medium">Add Users</span> - User Management → Create teachers/students
-                    </div>
-                  </li>
-                  <li className="flex gap-3">
-                    <span className="w-6 h-6 bg-purple-100 rounded-full flex items-center justify-center text-xs font-bold text-purple-600 flex-shrink-0 mt-0.5">2</span>
-                    <div>
-                      <span className="font-medium">Sync Records</span> - Fix data consistency with sync button
-                    </div>
-                  </li>
-                  <li className="flex gap-3">
-                    <span className="w-6 h-6 bg-purple-100 rounded-full flex items-center justify-center text-xs font-bold text-purple-600 flex-shrink-0 mt-0.5">3</span>
-                    <div>
-                      <span className="font-medium">Monitor Analytics</span> - Track system-wide performance
-                    </div>
-                  </li>
-                </ol>
-              </div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+          </button>
+
+          <button
+            type="button"
+            onClick={() => {
+              setSearchTerm('');
+              setSelectedCategory('all');
+              setExpandedSections((prev) => new Set(prev).add('analytics'));
+            }}
+            className="group flex items-start gap-3 rounded-2xl border border-emerald-200 bg-white p-4 text-left shadow-sm transition-all hover:-translate-y-0.5 hover:border-emerald-300 hover:shadow-md"
+          >
+            <div className="rounded-xl bg-emerald-100 p-2 text-emerald-700 transition-colors group-hover:bg-emerald-200">
+              <Calendar className="h-5 w-5" />
+            </div>
+            <div>
+              <div className="flex items-center gap-2 font-semibold text-slate-900">Attendance Insights</div>
+              <p className="mt-0.5 text-sm text-slate-600">
+                See historical trends and per-student rates, with low-attendance flags.
+              </p>
+            </div>
+          </button>
+        </div>
+      </div>
 
       {/* Search and Filters */}
-      <Card>
-        <CardContent className="p-6">
-          <div className="flex flex-col md:flex-row gap-4">
-            {/* Search */}
-            <div className="flex-1 relative">
-              <Search className="absolute left-3 top-3 h-4 w-4 text-gray-400" />
-              <Input
-                placeholder="Search help topics... (e.g., 'create task', 'attendance', 'export report')"
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Escape') {
-                    setSearchTerm('');
-                  } else if (e.key === 'Enter' && searchTerm && filteredContent.length > 0) {
-                    // Expand all matching sections
-                    const newExpanded = new Set(expandedSections);
-                    filteredContent.forEach(item => newExpanded.add(item.id));
-                    setExpandedSections(newExpanded);
-                  }
-                }}
-                className="pl-10"
-              />
-              {searchTerm && (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setSearchTerm('')}
-                  className="absolute right-2 top-1/2 -translate-y-1/2 h-6 w-6 p-0 text-gray-400 hover:text-gray-600"
-                >
-                  ×
-                </Button>
-              )}
-            </div>
-            
-            {/* Category Filter */}
-            <div className="flex flex-wrap gap-2">
-              {categories.map(category => {
-                const Icon = category.icon;
-                const isSelected = selectedCategory === category.id;
-                
-                // Filter categories based on user role
-                if (category.id === 'admin' && !isAdmin) return null;
-                
-                return (
-                  <Button
-                    key={category.id}
-                    variant={isSelected ? "default" : "outline"}
-                    size="sm"
-                    onClick={() => setSelectedCategory(category.id)}
-                    className="flex items-center gap-2"
-                  >
-                    <Icon className="h-4 w-4" />
-                    {category.label}
-                  </Button>
-                );
-              })}
-            </div>
-          </div>
-
-          {/* Search Results Summary */}
+      <div className="rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
+        <div className="relative">
+          <Search className="absolute left-4 top-1/2 h-4 w-4 -translate-y-1/2 text-slate-400" />
+          <Input
+            placeholder="Search help topics… (e.g. 'review queue', 'attendance', 'create task')"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') {
+                setSearchTerm('');
+              } else if (e.key === 'Enter' && searchTerm && filteredContent.length > 0) {
+                const newExpanded = new Set(expandedSections);
+                filteredContent.forEach(item => newExpanded.add(item.id));
+                setExpandedSections(newExpanded);
+              }
+            }}
+            className="h-11 rounded-xl border-slate-200 pl-11"
+          />
           {searchTerm && (
-            <div className="mt-4 p-3 bg-yellow-50 border border-yellow-200 rounded-lg">
-              <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2 text-sm">
-                  <Search className="h-4 w-4 text-yellow-600" />
-                  <span className="text-yellow-800">
-                    Found <strong>{filteredContent.length}</strong> result{filteredContent.length !== 1 ? 's' : ''} for "{searchTerm}"
-                  </span>
-                </div>
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setSearchTerm('')}
-                  className="text-yellow-700 hover:text-yellow-800 hover:bg-yellow-100"
-                >
-                  Clear search
-                </Button>
-              </div>
-              {filteredContent.length > 0 && (
-                <div className="mt-2 text-xs text-yellow-700">
-                  💡 Matching sections are automatically expanded and highlighted below
-                  <span className="ml-3 text-yellow-600">
-                    • Press <kbd className="px-1 py-0.5 bg-yellow-100 rounded text-xs">Enter</kbd> to expand all results
-                    • Press <kbd className="px-1 py-0.5 bg-yellow-100 rounded text-xs">Esc</kbd> to clear search
-                  </span>
-                </div>
-              )}
-            </div>
+            <button
+              type="button"
+              onClick={() => setSearchTerm('')}
+              aria-label="Clear search"
+              className="absolute right-3 top-1/2 flex h-6 w-6 -translate-y-1/2 items-center justify-center rounded-full text-slate-400 transition-colors hover:bg-slate-100 hover:text-slate-700"
+            >
+              ×
+            </button>
           )}
-        </CardContent>
-      </Card>
+        </div>
+
+        {/* Category pills */}
+        <div className="mt-4 flex flex-wrap gap-2">
+          {categories.map(category => {
+            const Icon = category.icon;
+            const isSelected = selectedCategory === category.id;
+            if (category.id === 'admin' && !isAdmin) return null;
+
+            return (
+              <button
+                key={category.id}
+                type="button"
+                onClick={() => setSelectedCategory(category.id)}
+                className={`flex items-center gap-2 rounded-full border px-3.5 py-1.5 text-sm font-medium transition-colors ${
+                  isSelected
+                    ? 'border-blue-600 bg-blue-600 text-white'
+                    : 'border-slate-200 bg-white text-slate-600 hover:border-blue-200 hover:bg-blue-50 hover:text-blue-700'
+                }`}
+              >
+                <Icon className="h-4 w-4" />
+                {category.label}
+              </button>
+            );
+          })}
+        </div>
+
+        {/* Search Results Summary */}
+        {searchTerm && (
+          <div className="mt-4 flex items-center justify-between rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm">
+            <span className="text-amber-800">
+              Found <strong>{filteredContent.length}</strong> result{filteredContent.length !== 1 ? 's' : ''} for "{searchTerm}"
+            </span>
+            <button
+              type="button"
+              onClick={() => setSearchTerm('')}
+              className="rounded-md px-2 py-1 text-amber-700 transition-colors hover:bg-amber-100 hover:text-amber-900"
+            >
+              Clear
+            </button>
+          </div>
+        )}
+      </div>
 
       {/* Help Content */}
       <div className="space-y-4">
@@ -673,19 +743,18 @@ const Help = () => {
               </p>
               
               {searchTerm && (
-                <div className="mt-6 p-4 bg-blue-50 rounded-lg border border-blue-200">
-                  <h4 className="font-medium text-blue-900 mb-3">💡 Try searching for:</h4>
-                  <div className="flex flex-wrap gap-2 justify-center">
-                    {['dashboard', 'create task', 'attendance', 'export report', 'user management', 'status filter', 'student progress'].map(suggestion => (
-                      <Button
+                <div className="mt-6 rounded-xl border border-blue-200 bg-blue-50 p-4">
+                  <h4 className="mb-3 font-medium text-blue-900">Try searching for:</h4>
+                  <div className="flex flex-wrap justify-center gap-2">
+                    {['review queue', 'attendance', 'create task', 'export report', 'user management', 'student progress'].map(suggestion => (
+                      <button
                         key={suggestion}
-                        variant="outline"
-                        size="sm"
+                        type="button"
                         onClick={() => setSearchTerm(suggestion)}
-                        className="text-xs border-blue-300 text-blue-700 hover:bg-blue-100"
+                        className="rounded-full border border-blue-200 bg-white px-3 py-1 text-xs font-medium text-blue-700 transition-colors hover:bg-blue-100 hover:text-blue-900"
                       >
                         {suggestion}
-                      </Button>
+                      </button>
                     ))}
                   </div>
                 </div>
@@ -698,29 +767,29 @@ const Help = () => {
             const isExpanded = expandedSections.has(item.id);
             
             return (
-              <Card key={item.id} className="overflow-hidden">
-                <CardHeader 
-                  className="cursor-pointer hover:bg-gray-50 transition-colors"
+              <Card key={item.id} className={`overflow-hidden rounded-2xl border-slate-200 transition-shadow ${isExpanded ? 'shadow-md' : 'hover:shadow-md'}`}>
+                <CardHeader
+                  className="cursor-pointer transition-colors hover:bg-slate-50"
                   onClick={() => toggleSection(item.id)}
                 >
-                  <CardTitle className="flex items-center justify-between">
-                    <div className="flex items-center gap-3">
-                      <Icon className="h-6 w-6 text-blue-600" />
-                      <span dangerouslySetInnerHTML={{ __html: highlightSearchTerm(item.title) }} />
-                      <Badge variant="secondary" className="text-xs">
-                        {item.category}
-                      </Badge>
+                  <CardTitle className="flex items-center justify-between gap-3">
+                    <div className="flex min-w-0 items-center gap-3">
+                      <div className={`flex h-10 w-10 flex-shrink-0 items-center justify-center rounded-xl ${isExpanded ? 'bg-blue-600 text-white' : 'bg-blue-50 text-blue-600'}`}>
+                        <Icon className="h-5 w-5" />
+                      </div>
+                      <span className="truncate text-base font-semibold text-slate-900" dangerouslySetInnerHTML={{ __html: highlightSearchTerm(item.title) }} />
+                      {'isNew' in item && item.isNew && (
+                        <Badge className="bg-gradient-to-r from-emerald-500 to-green-500 text-xs text-white hover:from-emerald-500 hover:to-green-500">
+                          New
+                        </Badge>
+                      )}
                       {searchTerm && (
-                        <Badge variant="outline" className="text-xs bg-yellow-50 border-yellow-300 text-yellow-700">
+                        <Badge variant="outline" className="border-amber-300 bg-amber-50 text-xs text-amber-700">
                           Match
                         </Badge>
                       )}
                     </div>
-                    {isExpanded ? (
-                      <ChevronDown className="h-5 w-5 text-gray-400" />
-                    ) : (
-                      <ChevronRight className="h-5 w-5 text-gray-400" />
-                    )}
+                    <ChevronDown className={`h-5 w-5 flex-shrink-0 text-slate-400 transition-transform duration-200 ${isExpanded ? 'rotate-180' : ''}`} />
                   </CardTitle>
                 </CardHeader>
                 
@@ -741,6 +810,11 @@ const Help = () => {
                                 {index + 1}
                               </div>
                               <span dangerouslySetInnerHTML={{ __html: highlightSearchTerm(section.title) }} />
+                              {'isNew' in section && section.isNew && (
+                                <Badge className="text-xs bg-gradient-to-r from-emerald-500 to-green-500 text-white hover:from-emerald-500 hover:to-green-500">
+                                  New
+                                </Badge>
+                              )}
                               {sectionHasMatch && (
                                 <Badge variant="outline" className="text-xs bg-yellow-100 border-yellow-400 text-yellow-700 ml-2">
                                   🔍
@@ -779,35 +853,14 @@ const Help = () => {
         )}
       </div>
 
-      {/* Quick Actions */}
-      <Card className="bg-blue-50 border-blue-200">
-        <CardContent className="p-6">
-          <div className="flex items-center gap-3 mb-4">
-            <Lightbulb className="h-6 w-6 text-blue-600" />
-            <h3 className="text-lg font-semibold text-blue-900">Quick Start Tips</h3>
-          </div>
-          <div className="grid md:grid-cols-2 gap-4 text-sm">
-            <div className="space-y-2">
-              <p className="font-medium text-blue-800">For New Teachers:</p>
-              <ul className="space-y-1 text-blue-700">
-                <li>• Start with the Dashboard to see your students</li>
-                <li>• Create your first task in "Manage Tasks"</li>
-                <li>• Check attendance daily using the Attendance tab</li>
-              </ul>
-            </div>
-            {isAdmin && (
-              <div className="space-y-2">
-                <p className="font-medium text-blue-800">For Administrators:</p>
-                <ul className="space-y-1 text-blue-700">
-                  <li>• Set up users in User Management first</li>
-                  <li>• Sync student records after adding users</li>
-                  <li>• Monitor system usage in Analytics</li>
-                </ul>
-              </div>
-            )}
-          </div>
-        </CardContent>
-      </Card>
+      {/* Footer */}
+      <div className="flex flex-col items-center gap-1 rounded-2xl border border-slate-200 bg-white p-5 text-center shadow-sm">
+        <div className="flex items-center gap-2 text-sm font-medium text-slate-700">
+          <Lightbulb className="h-4 w-4 text-blue-600" />
+          Still stuck? Search above or contact your administrator.
+        </div>
+        <p className="text-xs text-slate-400">ARCC Student Progress Tracker</p>
+      </div>
     </div>
   );
 };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -57,6 +57,22 @@ const Index = () => {
     console.log('Index: Today\'s attendance count:', todayAttendance.length);
   }, [isAdmin, isTeacher, isStudent, subjects, tasks, attendanceRecords]);
 
+  // Force more aggressive data refresh in presentation mode.
+  // Keep this hook above all returns so the hook order stays stable.
+  React.useEffect(() => {
+    if (!isPresentationMode) return;
+
+    const interval = setInterval(() => {
+      console.log('🔄 Presentation mode: Force refreshing data...');
+      refetchTasks();
+      refetchStudents();
+      refetchSubjects();
+      refetchAttendance();
+    }, 5000);
+
+    return () => clearInterval(interval);
+  }, [isPresentationMode, refetchTasks, refetchStudents, refetchSubjects, refetchAttendance]);
+
   if (!user) {
     return (
       <div className="p-6">
@@ -127,6 +143,7 @@ const Index = () => {
       status: task.status,
       timeInStatus: task.time_in_status || 0,
       createdAt: task.created_at,
+      updatedAt: task.updated_at,
       teacher_feedback_type: task.teacher_feedback_type,
       teacher_feedback_message: task.teacher_feedback_message,
       teacher_next_steps: task.teacher_next_steps,
@@ -290,19 +307,6 @@ const Index = () => {
 
   // In presentation mode, only show the FleetBoard with minimal styling
   if (isPresentationMode) {
-    // Force more aggressive data refresh in presentation mode
-    React.useEffect(() => {
-      const interval = setInterval(() => {
-        console.log('🔄 Presentation mode: Force refreshing data...');
-        refetchTasks();
-        refetchStudents();
-        refetchSubjects();
-        refetchAttendance();
-      }, 5000); // Every 5 seconds in presentation mode
-
-      return () => clearInterval(interval);
-    }, [refetchTasks, refetchStudents, refetchSubjects, refetchAttendance]);
-
     return (
       <div className="w-full min-h-screen p-4">
         {/* Simple header for presentation mode */}

--- a/src/pages/ReviewQueue.tsx
+++ b/src/pages/ReviewQueue.tsx
@@ -1,0 +1,215 @@
+import React, { useMemo, useState } from 'react';
+import { CheckCircle, Clock, MessageSquare, RotateCcw, UserRound } from 'lucide-react';
+import { PermissionGuard } from '@/components/PermissionGuard';
+import { TeacherFeedbackDialog } from '@/components/TeacherFeedbackDialog';
+import { useTasks } from '@/hooks/useTasks';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import type { Task } from '@/types/task';
+
+const getAgeInDays = (dateValue: string) => {
+  const timestamp = new Date(dateValue).getTime();
+  if (Number.isNaN(timestamp)) return 0;
+  return Math.max(0, Math.floor((Date.now() - timestamp) / (1000 * 60 * 60 * 24)));
+};
+
+const formatSubmittedAge = (dateValue: string) => {
+  const days = getAgeInDays(dateValue);
+  if (days === 0) return 'Today';
+  if (days === 1) return '1 day ago';
+  return `${days} days ago`;
+};
+
+const ReviewQueue = () => {
+  const { tasks, loading, updateTask, isUpdating } = useTasks();
+  const [feedbackTask, setFeedbackTask] = useState<Task | null>(null);
+
+  const readyReviewTasks = useMemo(() => {
+    return tasks
+      .filter((task) => task.status === 'ready-review')
+      .sort((a, b) => new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime());
+  }, [tasks]);
+
+  const groupedBySubject = useMemo(() => {
+    return readyReviewTasks.reduce<Record<string, Task[]>>((groups, task) => {
+      const subjectName = task.subjects?.name || 'No Subject';
+      if (!groups[subjectName]) groups[subjectName] = [];
+      groups[subjectName].push(task);
+      return groups;
+    }, {});
+  }, [readyReviewTasks]);
+
+  const oldestDays = readyReviewTasks.length > 0
+    ? Math.max(...readyReviewTasks.map((task) => getAgeInDays(task.updated_at)))
+    : 0;
+
+  const handleMarkComplete = (task: Task) => {
+    updateTask({
+      taskId: task.id,
+      updates: { status: 'completed' }
+    });
+  };
+
+  const handleSendBackToWorking = (task: Task) => {
+    updateTask({
+      taskId: task.id,
+      updates: { status: 'working' }
+    });
+  };
+
+  return (
+    <PermissionGuard
+      requiredRoles={['admin', 'teacher']}
+      fallbackMessage="You don't have permission to review learning activities."
+    >
+      <div className="p-6 space-y-6 bg-gradient-to-br from-slate-50 via-blue-50/40 to-indigo-50/50 min-h-full">
+        <Card className="overflow-hidden border-blue-100 bg-white/90 shadow-lg">
+          <CardContent className="p-0">
+            <div className="flex flex-col gap-5 border-b border-blue-100 bg-gradient-to-r from-white via-blue-50 to-indigo-50 p-6 lg:flex-row lg:items-center lg:justify-between">
+              <div className="flex items-start gap-4">
+                <div className="rounded-2xl bg-blue-600/10 p-3">
+                  <CheckCircle className="h-7 w-7 text-blue-700" />
+                </div>
+                <div>
+                  <h1 className="text-2xl font-bold tracking-tight text-slate-950">Review Queue</h1>
+                  <p className="mt-1 max-w-2xl text-sm text-slate-600">
+                    Clear submitted learning activities, send work back when revisions are needed, or complete work with feedback in one focused flow.
+                  </p>
+                </div>
+              </div>
+              <div className="grid grid-cols-2 gap-3 sm:min-w-[260px]">
+                <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-center shadow-sm">
+                  <div className="text-3xl font-bold text-amber-800">{readyReviewTasks.length}</div>
+                  <div className="text-xs font-semibold uppercase tracking-wide text-amber-700">Ready Review</div>
+                </div>
+                <div className="rounded-2xl border border-blue-200 bg-blue-50 px-4 py-3 text-center shadow-sm">
+                  <div className="text-3xl font-bold text-blue-800">{oldestDays}</div>
+                  <div className="text-xs font-semibold uppercase tracking-wide text-blue-700">Oldest Days</div>
+                </div>
+              </div>
+            </div>
+
+            <div className="p-6">
+              <div className="mb-5 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h2 className="flex items-center gap-2 text-lg font-semibold text-slate-950">
+                    <Clock className="h-5 w-5 text-amber-600" />
+                    Activities Awaiting Teacher Review
+                  </h2>
+                  <p className="text-sm text-slate-500">
+                    Use "Complete + Feedback" to approve work and give the student feedback in one save.
+                  </p>
+                </div>
+              </div>
+
+            {loading ? (
+              <div className="py-12 text-center text-blue-600">Loading review queue...</div>
+            ) : readyReviewTasks.length === 0 ? (
+              <div className="py-10 text-center">
+                <CheckCircle className="mx-auto mb-3 h-10 w-10 text-emerald-500" />
+                <h3 className="font-semibold text-gray-900">Review queue is clear</h3>
+                <p className="text-sm text-gray-600">No activities are waiting for teacher review.</p>
+              </div>
+            ) : (
+              <div className="space-y-8">
+                {Object.entries(groupedBySubject).map(([subjectName, subjectTasks]) => (
+                  <section key={subjectName} className="space-y-3">
+                    <div className="flex items-center justify-between border-b border-slate-200 pb-2">
+                      <h3 className="text-sm font-bold uppercase tracking-wide text-slate-700">{subjectName}</h3>
+                      <Badge variant="outline" className="border-amber-200 bg-amber-50 text-amber-700">
+                        {subjectTasks.length} to review
+                      </Badge>
+                    </div>
+                    <div className="space-y-3">
+                      {subjectTasks.map((task) => (
+                        <article
+                          key={task.id}
+                          className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition-all duration-200 hover:-translate-y-0.5 hover:border-blue-200 hover:shadow-md"
+                        >
+                          <div className="grid gap-4 xl:grid-cols-[1.3fr_1fr_auto] xl:items-center">
+                            <div className="min-w-0">
+                              <div className="flex flex-wrap items-center gap-2">
+                                <h4 className="font-semibold text-slate-950">{task.title}</h4>
+                                <Badge className="bg-amber-100 text-amber-800 hover:bg-amber-100">
+                                  {formatSubmittedAge(task.updated_at)}
+                                </Badge>
+                              </div>
+                              {task.description && (
+                                <p className="mt-1 line-clamp-2 text-sm text-slate-500" title={task.description}>
+                                  {task.description}
+                                </p>
+                              )}
+                            </div>
+
+                            <div className="flex min-w-0 items-center gap-3 rounded-xl bg-slate-50 px-3 py-2">
+                              <div className="rounded-full bg-white p-2 shadow-sm">
+                                <UserRound className="h-4 w-4 text-slate-500" />
+                              </div>
+                              <div className="min-w-0">
+                                <div className="truncate text-sm font-medium text-slate-900">
+                                  {task.students?.name || 'Unknown Student'}
+                                </div>
+                                {task.students?.email && (
+                                  <div className="truncate text-xs text-slate-500">{task.students.email}</div>
+                                )}
+                              </div>
+                            </div>
+
+                            <div className="flex flex-col gap-2 sm:flex-row xl:justify-end">
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() => handleSendBackToWorking(task)}
+                                disabled={isUpdating}
+                                className="border border-slate-200 bg-white text-slate-700 shadow-sm hover:bg-slate-50 hover:text-slate-950 disabled:text-slate-700"
+                              >
+                                <RotateCcw className="h-3 w-3" />
+                                Send Back
+                              </Button>
+                              <Button
+                                size="sm"
+                                variant="ghost"
+                                onClick={() => handleMarkComplete(task)}
+                                disabled={isUpdating}
+                                className="border border-emerald-200 bg-emerald-50 text-emerald-700 shadow-sm hover:bg-emerald-100 hover:text-emerald-900 disabled:text-emerald-700"
+                              >
+                                <CheckCircle className="h-3 w-3" />
+                                Mark Complete
+                              </Button>
+                              <Button
+                                size="sm"
+                                onClick={() => setFeedbackTask(task)}
+                                disabled={isUpdating}
+                                className="bg-gradient-to-r from-blue-600 to-indigo-600 text-white shadow-md hover:from-blue-700 hover:to-indigo-700 hover:text-white disabled:text-white"
+                              >
+                                <MessageSquare className="h-3 w-3" />
+                                Complete + Feedback
+                              </Button>
+                            </div>
+                          </div>
+                        </article>
+                      ))}
+                    </div>
+                  </section>
+                ))}
+              </div>
+            )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {feedbackTask && (
+          <TeacherFeedbackDialog
+            task={feedbackTask}
+            open={!!feedbackTask}
+            completeOnSave
+            onOpenChange={(open) => !open && setFeedbackTask(null)}
+          />
+        )}
+      </div>
+    </PermissionGuard>
+  );
+};
+
+export default ReviewQueue;

--- a/src/types/workflow.ts
+++ b/src/types/workflow.ts
@@ -16,6 +16,7 @@ export interface Task {
   timeInStatus: number; // minutes in current status
   dueDate?: string;
   createdAt?: string;
+  updatedAt?: string;
   // Teacher feedback fields
   teacher_feedback_type?: 'thumbs_up' | 'thumbs_down' | 'neutral' | null;
   teacher_feedback_message?: string | null;


### PR DESCRIPTION
- Review Queue (/review): teachers clear ready-review work with Send Back, Mark Complete, and Complete + Feedback (single mutation), plus sidebar badge.
- Allow teacher feedback at ready-review; relabel dialog "Submitted".
- FleetBoard "needs attention" now derives age from updated_at/created_at (time_in_status was never populated); TaskCard minute display unchanged.
- Attendance Insights in Analytics via new read-only useAttendanceHistory hook (useAttendance untouched): monthly trend, per-student rates, <90% flag, CSV/print.
- Replace mock analytics (random completion time, hardcoded response time, placeholder grade) with real computed values and "No data yet" states.
- Full Help page redesign with New labels for the new features.

No DB/schema changes.